### PR TITLE
Fixed wrong condition

### DIFF
--- a/src/Gnugat/Redaktilo/Editor.php
+++ b/src/Gnugat/Redaktilo/Editor.php
@@ -85,7 +85,7 @@ class Editor
         $lines = $file->readlines();
         $filename = $file->getFilename();
         $currentLineNumber = $file->getCurrentLineNumber() + 1;
-        $length = count($lines);
+        $length = count($lines) - $currentLineNumber;
         while ($currentLineNumber < $length) {
             if ($lines[$currentLineNumber] === $pattern) {
                 $file->setCurrentLineNumber($currentLineNumber);


### PR DESCRIPTION
Assume you started on line 42 of a 120 long file, the loop will go until line 164 instead of 120 if it doesn't find one.
