### PR TITLE
Fixed checks in Text#getLine

### DIFF
--- a/src/Gnugat/Redaktilo/Text.php
+++ b/src/Gnugat/Redaktilo/Text.php
@@ -133,7 +133,7 @@ class Text
      */
     public function getLine($lineNumber = null)
     {
-        if (!$lineNumber) {
+        if (null === $lineNumber) {
             $lineNumber = $this->currentLineNumber;
         }
         $this->throwOnInvalidLineNumber($lineNumber);
@@ -153,7 +153,7 @@ class Text
      */
     public function setLine($line, $lineNumber = null)
     {
-        if (!$lineNumber) {
+        if (null === $lineNumber) {
             $lineNumber = $this->currentLineNumber;
         }
         $this->throwOnInvalidLineNumber($lineNumber);


### PR DESCRIPTION
With the current check, we can never get the first line if it isn't the current line (since `!0` is `true`).
