### PR TITLE
[Doc] fix statics notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@
 * removed TextFactory
 * removed Text#__construct
 * removed LineBreak
-* added Text#fromArray
-* added Text#fromString
-* added StringUtil#detectLineBreak
+* added Text::fromArray
+* added Text::fromString
+* added StringUtil::detectLineBreak
 
 ## 1.5.0: Current line number Incrementation
 

--- a/doc/03-reference.md
+++ b/doc/03-reference.md
@@ -190,7 +190,7 @@ class Text
 > **Important**: `lines` is an array of string stripped from their line break
 > character.
 
-If you need to manipulate a simple string you can use `Text#fromString`:
+If you need to manipulate a simple string you can use `Text::fromString`:
 
 ```php
 <?php
@@ -206,7 +206,7 @@ $text = Text::fromString("why do witches burn?\n...because they're made of... wo
 
 ### Side note on Line Breaks
 
-A `StringUtil#detectLineBreak` method is used to find the line break, this is
+A `StringUtil::detectLineBreak` method is used to find the line break, this is
 done using the following rules:
 
 * `\r\n` for windows


### PR DESCRIPTION
Fixes #112
I also found that `Text::fromArray` and `Text::fromString` were in the same case ;)