### PR TITLE
More composer fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,5 +36,10 @@
         "phpspec/phpspec": "~2.1",
         "phpunit/phpunit": ">=3.7,<5.0",
         "bossa/phpspec2-expect": "~1.0"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.0-dev"
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "symfony/filesystem": "~2.3"
     },
     "require-dev": {
-        "phpspec/phpspec": "~2.1@rc",
+        "phpspec/phpspec": "~2.1",
         "phpunit/phpunit": ">=3.7,<5.0",
         "bossa/phpspec2-expect": "~1.0"
     }


### PR DESCRIPTION
* PHPspec 2.1 is stable, no need to require RC
* Added branch alias, so we don't have to use `dev-master`, but the much better `2.0.*@dev`. This needs to be updated each release to have the next version